### PR TITLE
Update tock.md with correct 'last-updated' year

### DIFF
--- a/content/rtos/tock.md
+++ b/content/rtos/tock.md
@@ -4,7 +4,7 @@ components:
 - None
 date: 2019-02-12 05:45:10
 draft: false
-last-updated: '2019-05-08'
+last-updated: '2020-05-08'
 libraries:
 - None
 licenses:


### PR DESCRIPTION
Fixing after previously overlooking the year